### PR TITLE
Return proper response from delete

### DIFF
--- a/src/templates/APIController
+++ b/src/templates/APIController
@@ -34,6 +34,6 @@ class ___MODEL___APIController extends Controller
         $___MODEL_INSTANCE___ = ___MODEL___::findOrFail($id);
         $___MODEL_INSTANCE___->delete();
 
-        return 204;
+        return response()->json([], \Illuminate\Http\Response::HTTP_NO_CONTENT);
     }
 }


### PR DESCRIPTION
A delete request should return a proper request with the `no content` status code.