### PR TITLE
Relationships model references

### DIFF
--- a/src/templates/BelongsToManyRelationship
+++ b/src/templates/BelongsToManyRelationship
@@ -3,5 +3,5 @@
  */
 public function ___METHOD_NAME___()
 {
-    return $this->belongsToMany('App\___TARGET_CLASS___');
+    return $this->belongsToMany(\App\___TARGET_CLASS___::class);
 }

--- a/src/templates/BelongsToRelationship
+++ b/src/templates/BelongsToRelationship
@@ -3,5 +3,5 @@
  */
 public function ___METHOD_NAME___()
 {
-    return $this->belongsTo('App\___TARGET_CLASS___');
+    return $this->belongsTo(\App\___TARGET_CLASS___::class);
 }

--- a/src/templates/HasManyRelationship
+++ b/src/templates/HasManyRelationship
@@ -3,5 +3,5 @@
  */
 public function ___METHOD_NAME___()
 {
-    return $this->hasMany('App\___TARGET_CLASS___');
+    return $this->hasMany(\App\___TARGET_CLASS___::class);
 }

--- a/src/templates/HasOneRelationship
+++ b/src/templates/HasOneRelationship
@@ -3,5 +3,5 @@
  */
 public function ___METHOD_NAME___()
 {
-    return $this->hasOne('App\___TARGET_CLASS___');
+    return $this->hasOne(\App\___TARGET_CLASS___::class);
 }


### PR DESCRIPTION
Using the `::class` constant instead of strings in model relationships.
This will make a bunch of IDEs happier ;)