### PR TITLE
Add aliases for package modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 node_modules
 migrations_metadata.csv
+.idea/

--- a/package.json
+++ b/package.json
@@ -32,5 +32,12 @@
         "vue-highlightjs": "^1.3.3",
         "vue-textarea-autosize": "^1.0.4",
         "vuex": "^3.1.0"
+    },
+    "_moduleAliases": {
+        "@utilities": "src/resources/js/utilities",
+        "@pipes": "src/resources/js/fileFactories/Laravel/pipes",
+        "@preferences": "src/resources/js/fileFactories/Laravel/preferences",
+        "@sketches": "src/resources/js/fileFactories/Laravel/sketches",
+        "@entities": "src/resources/js/objectModel/entities"
     }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "@pipes": "src/resources/js/fileFactories/Laravel/pipes",
         "@preferences": "src/resources/js/fileFactories/Laravel/preferences",
         "@sketches": "src/resources/js/fileFactories/Laravel/sketches",
-        "@entities": "src/resources/js/objectModel/entities"
+        "@entities": "src/resources/js/objectModel/entities",
+        "@": "src/resources/js"
     }
 }

--- a/src/Commands/DumpAutoload.php
+++ b/src/Commands/DumpAutoload.php
@@ -32,6 +32,7 @@ class DumpAutoload extends Command
      * Create a new command instance.
      *
      * @param Composer $composer
+     *
      * @return void
      */
     public function __construct(Composer $composer)

--- a/src/Controllers/PipeDreamAPIController.php
+++ b/src/Controllers/PipeDreamAPIController.php
@@ -2,13 +2,13 @@
 
 namespace PipeDream\Laravel\Controllers;
 
-use Illuminate\Foundation\Bus\DispatchesJobs;
-use Illuminate\Routing\Controller as BaseController;
-use Illuminate\Foundation\Validation\ValidatesRequests;
-use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
-use File;
-use PipeDream\Laravel\ProjectFileManager;
 use Artisan;
+use File;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Routing\Controller as BaseController;
+use PipeDream\Laravel\ProjectFileManager;
 
 class PipeDreamAPIController extends BaseController
 {
@@ -21,17 +21,16 @@ class PipeDreamAPIController extends BaseController
 
     public function templates()
     {
-        
         return $this->getTemplates();
     }
 
     public function scripts()
     {
         return [
-            "migrate",
-            "seed"
+            'migrate',
+            'seed',
         ];
-    }   
+    }
 
     public function build()
     {
@@ -40,7 +39,7 @@ class PipeDreamAPIController extends BaseController
 
         // Optionally reverse the previous design iteration
         // This is useful to remove previous mistakes and timestamp conflicts
-        $this->args->reverseHistory? $this->project->reverseHistory() : null;
+        $this->args->reverseHistory ? $this->project->reverseHistory() : null;
 
         // Write the files generated
         $this->project->write($this->args->reviewFiles);
@@ -54,12 +53,10 @@ class PipeDreamAPIController extends BaseController
         // Ensure migrations are autoloaded
         exec('cd .. && composer dumpautoload');
         // whats wrong with this package command??!!
-        //Artisan::call('dump-autoload'); 
-        
-        
+        //Artisan::call('dump-autoload');
 
         return response([
-            "message" => "Successfully stored files!"
+            'message' => 'Successfully stored files!',
         ], 200);
     }
 
@@ -70,7 +67,8 @@ class PipeDreamAPIController extends BaseController
         );
     }
 
-    private function deleteDefaultMigrations() {
+    private function deleteDefaultMigrations()
+    {
         $this->project->delete(json_decode('
             [
                 {
@@ -82,7 +80,7 @@ class PipeDreamAPIController extends BaseController
             ]
         '));
     }
-    
+
     private function pathToFileName($path)
     {
         return substr($path, strrpos($path, '/') + 1);
@@ -90,8 +88,9 @@ class PipeDreamAPIController extends BaseController
 
     private function getTemplates()
     {
-        return collect(glob(__DIR__ . '/../templates/*'))->reduce(function($allFiles, $path) {
+        return collect(glob(__DIR__.'/../templates/*'))->reduce(function ($allFiles, $path) {
             $allFiles[$this->pathToFileName($path)] = File::get($path);
+
             return $allFiles;
         }, collect([]));
     }

--- a/src/Controllers/PipeDreamWebController.php
+++ b/src/Controllers/PipeDreamWebController.php
@@ -12,10 +12,10 @@ class PipeDreamWebController extends BaseController
         PipeDreamServiceProvider::publishAssets();
 
         return view('pipe-dream::spa')->with([
-            "settings" => [
-                "isSandboxed" => env('PIPEDREAM_IS_SANDBOXED', false),
-                "appName" => request()->path() 
-            ]
-        ]);        
+            'settings' => [
+                'isSandboxed' => env('PIPEDREAM_IS_SANDBOXED', false),
+                'appName'     => request()->path(),
+            ],
+        ]);
     }
 }

--- a/src/PipeDreamServiceProvider.php
+++ b/src/PipeDreamServiceProvider.php
@@ -3,7 +3,6 @@
 namespace PipeDream\Laravel;
 
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Support\Collection;
 use PipeDream\Laravel\Commands\DumpAutoload;
 
 class PipeDreamServiceProvider extends ServiceProvider
@@ -16,7 +15,7 @@ class PipeDreamServiceProvider extends ServiceProvider
     public function register()
     {
         $this->commands([
-            DumpAutoload::class
+            DumpAutoload::class,
         ]);
     }
 
@@ -38,33 +37,34 @@ class PipeDreamServiceProvider extends ServiceProvider
     * So resorting to do it every new page load
     * Please fix this
     */
-    public static function publishAssets() {
+    public static function publishAssets()
+    {
         \File::copyDirectory(
-            __DIR__ . '/public',
+            __DIR__.'/public',
             public_path('vendor/pipe-dream/laravel')
         );
 
         \File::copy(
-            __DIR__ . '/../data/dataTypeGithubDump.js',
+            __DIR__.'/../data/dataTypeGithubDump.js',
             public_path('vendor/pipe-dream/laravel/data/github.js')
-        );        
+        );
     }
-    
+
     private function registerStorages()
     {
-        $this->app['config']["filesystems.disks.self"] = [
+        $this->app['config']['filesystems.disks.self'] = [
             'driver' => 'local',
-            'root' => base_path(),
+            'root'   => base_path(),
         ];
 
-        $this->app['config']["filesystems.disks.pipe-dream"] = [
+        $this->app['config']['filesystems.disks.pipe-dream'] = [
             'driver' => 'local',
-            'root' => storage_path('pipe-dream'),
+            'root'   => storage_path('pipe-dream'),
         ];
-        
-        $this->app['config']["filesystems.disks.pipe-dream.sandbox"] = [
+
+        $this->app['config']['filesystems.disks.pipe-dream.sandbox'] = [
             'driver' => 'local',
-            'root' => storage_path('pipe-dream/sandbox'),
-        ];        
+            'root'   => storage_path('pipe-dream/sandbox'),
+        ];
     }
 }

--- a/src/ProjectFileManager.php
+++ b/src/ProjectFileManager.php
@@ -2,15 +2,17 @@
 
 namespace PipeDream\Laravel;
 
-use stdClass;
-use Storage;
 use File;
+use Storage;
 
-class ProjectFileManager {
+class ProjectFileManager
+{
     public function __construct($isSandboxed)
     {
         $this->isSandboxed = $isSandboxed;
-        if($this->isSandboxed) $this->setupSandboxProject();            
+        if ($this->isSandboxed) {
+            $this->setupSandboxProject();
+        }
         $this->history = [];
     }
 
@@ -23,27 +25,27 @@ class ProjectFileManager {
     {
         $this->recordCurrentStateFor($files);
 
-        collect($files)->each(function($file) {
+        collect($files)->each(function ($file) {
             $this->storage()->put($file->path, $file->content);
-        });        
+        });
     }
 
     public function delete($files)
     {
         $this->recordCurrentStateFor($files);
 
-        collect($files)->each(function($file) {
+        collect($files)->each(function ($file) {
             $this->storage()->delete($file->path);
-        });        
-    }    
+        });
+    }
 
     public function reverseHistory()
     {
-        collect($this->loadHistory())->each(function($content, $path) {
-            if($content == null) {
+        collect($this->loadHistory())->each(function ($content, $path) {
+            if ($content == null) {
                 return $this->storage()->delete($path);
             }
-            
+
             $this->storage()->put($path, $content);
         });
     }
@@ -59,15 +61,15 @@ class ProjectFileManager {
     /*********** PRIVATE ************************************************** */
     private function setupSandboxProject()
     {
-        app()['config']["filesystems.disks.pipe-dream-sandbox-project"] = [
+        app()['config']['filesystems.disks.pipe-dream-sandbox-project'] = [
             'driver' => 'local',
-            'root' => storage_path("pipe-dream/sandbox/test-project"),
-        ]; 
-        
-        if(!Storage::disk('pipe-dream')->exists('sandbox/test-project')) {
+            'root'   => storage_path('pipe-dream/sandbox/test-project'),
+        ];
+
+        if (!Storage::disk('pipe-dream')->exists('sandbox/test-project')) {
             File::copyDirectory(
                 storage_path('pipe-dream/laravel-including-vendors'),
-                storage_path("pipe-dream/sandbox/test-project")
+                storage_path('pipe-dream/sandbox/test-project')
             );
         }
     }
@@ -81,14 +83,14 @@ class ProjectFileManager {
     private function storage()
     {
         return Storage::disk(
-            $this->isSandboxed ? "pipe-dream-sandbox-project" : 'self'
+            $this->isSandboxed ? 'pipe-dream-sandbox-project' : 'self'
         );
     }
 
     private function recordCurrentStateFor($files)
     {
-        collect($files)->each(function($file) {
-            $this->history[$file->path] = 
+        collect($files)->each(function ($file) {
+            $this->history[$file->path] =
                 $this->storage()->has($file->path) ?
                 $this->storage()->get($file->path) :
                 null;

--- a/src/resources/js/components/AppHeader.vue
+++ b/src/resources/js/components/AppHeader.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script>
-    import Config from '../Config'
+    import Config from '@/Config'
 
     export default {
         data() {

--- a/src/resources/js/fileFactories/Laravel/FileFactory.js
+++ b/src/resources/js/fileFactories/Laravel/FileFactory.js
@@ -1,8 +1,8 @@
 
-import defaultPreferences from './preferences/defaultSchema'
-import userSystemSketch from './sketches/userSystemSketch'
-import sampleAppSketch from './sketches/sampleAppSketch'
-import helpSketch from './sketches/helpSketch'
+import defaultPreferences from '@preferences/defaultSchema'
+import userSystemSketch from '@sketches/userSystemSketch'
+import sampleAppSketch from '@sketches/sampleAppSketch'
+import helpSketch from '@sketches/helpSketch'
 import collect from 'collect.js'
 const pipes = require.context('./pipes', false, /\.js$/);
 

--- a/src/resources/js/fileFactories/Laravel/pipes/APIControllerPipe.js
+++ b/src/resources/js/fileFactories/Laravel/pipes/APIControllerPipe.js
@@ -1,6 +1,6 @@
-import Template from '../../../utilities/Template'
+import Template from '@utilities/Template'
 import ModelPipe from './ModelPipe';
-import F from '../../../utilities/Formatter'
+import F from '@utilities/Formatter'
 
 export default class APIControllerPipe extends ModelPipe {
     calculateFiles(omc = ObjectModelCollection) {

--- a/src/resources/js/fileFactories/Laravel/pipes/APIRoutesPipe.js
+++ b/src/resources/js/fileFactories/Laravel/pipes/APIRoutesPipe.js
@@ -1,6 +1,6 @@
-import Template from '../../../utilities/Template'
+import Template from '@utilities/Template'
 import BasePipe from './BasePipe'
-import F from '../../../utilities/Formatter.js'
+import F from '@utilities/Formatter.js'
 
 export default class APIRoutesPipe extends BasePipe {
     calculateFiles() {        

--- a/src/resources/js/fileFactories/Laravel/pipes/ControllerPipe.js
+++ b/src/resources/js/fileFactories/Laravel/pipes/ControllerPipe.js
@@ -1,4 +1,4 @@
-import Template from '../../../utilities/Template'
+import Template from '@utilities/Template'
 import ModelPipe from './ModelPipe';
 
 export default class ControllerPipe extends ModelPipe {

--- a/src/resources/js/fileFactories/Laravel/pipes/FactoryPipe.js
+++ b/src/resources/js/fileFactories/Laravel/pipes/FactoryPipe.js
@@ -1,7 +1,7 @@
-import Template from '../../../utilities/Template'
+import Template from '@utilities/Template'
 import ModelPipe from './ModelPipe'
 
-import F from '../../../utilities/Formatter'
+import F from '@utilities/Formatter'
 import { random } from 'node-forge';
 
 export default class FactoryPipe extends ModelPipe {

--- a/src/resources/js/fileFactories/Laravel/pipes/MigrationPipe.js
+++ b/src/resources/js/fileFactories/Laravel/pipes/MigrationPipe.js
@@ -1,7 +1,7 @@
-import Template from '../../../utilities/Template'
+import Template from '@utilities/Template'
 import BasePipe from './BasePipe'
-import F from '../../../utilities/Formatter'
-import ModelEntity from '../../../objectModel/entities/ModelEntity';
+import F from '@utilities/Formatter'
+import ModelEntity from '@entities/ModelEntity';
 
 export default class MigrationPipe extends BasePipe {
     calculateFiles(omc = ObjectModelCollection) {

--- a/src/resources/js/fileFactories/Laravel/pipes/ModelPipe.js
+++ b/src/resources/js/fileFactories/Laravel/pipes/ModelPipe.js
@@ -47,6 +47,17 @@ export default class ModelPipe extends BasePipe {
     
     relationshipMethods(model) {
         return [
+            model.relationships.hasOne.map(target => {
+                return Template.for('HasOneRelationship').replace({
+                    ___TARGET_CLASS___: target.className(),                    
+                    ___THIS_CLASS___: model.className(),
+                    ___METHOD_NAME___: F.camelCase(
+                        target.className()
+                    ),
+
+                })
+            }).join(___DOUBLE_LINE_BREAK___),
+
             model.relationships.hasMany.map(target => {
                 return Template.for('HasManyRelationship').replace({
                     ___TARGET_CLASS___: target.className(),                    

--- a/src/resources/js/fileFactories/Laravel/pipes/ModelPipe.js
+++ b/src/resources/js/fileFactories/Laravel/pipes/ModelPipe.js
@@ -1,6 +1,6 @@
-import Template from '../../../utilities/Template'
+import Template from '@utilities/Template'
 import BasePipe from './BasePipe'
-import F from '../../../utilities/Formatter'
+import F from '@utilities/Formatter'
 
 export default class ModelPipe extends BasePipe {
     calculateFiles(omc = ObjectModelCollection) {

--- a/src/resources/js/fileFactories/Laravel/pipes/SeederPipe.js
+++ b/src/resources/js/fileFactories/Laravel/pipes/SeederPipe.js
@@ -1,8 +1,8 @@
-import Template from '../../../utilities/Template'
+import Template from '@utilities/Template'
 import ModelPipe from './ModelPipe'
-import ModelEntity from '../../../objectModel/entities/ModelEntity'
+import ModelEntity from '@entities/ModelEntity'
 
-import F from '../../../utilities/Formatter'
+import F from '@utilities/Formatter'
 
 export default class SeederPipe extends ModelPipe {
     calculateFiles(omc = ObjectModelCollection) {

--- a/src/resources/js/fileFactories/Laravel/pipes/UserPipe.js
+++ b/src/resources/js/fileFactories/Laravel/pipes/UserPipe.js
@@ -1,4 +1,4 @@
-import Template from '../../../utilities/Template'
+import Template from '@utilities/Template'
 import ModelPipe from './ModelPipe';
 
 export default class UserPipe extends ModelPipe {

--- a/src/resources/js/objectModel/AttributeFactory.js
+++ b/src/resources/js/objectModel/AttributeFactory.js
@@ -1,6 +1,6 @@
 import Attribute from './Attribute'
-import Preference from '../utilities/Preference'
-import F from '../utilities/Formatter'
+import Preference from '@utilities/Preference'
+import F from '@utilities/Formatter'
 import getDataType from './attributePropertyResolvers/getDataType'
 
 export default class AttributeFactory {

--- a/src/resources/js/objectModel/ObjectModelCollection.js
+++ b/src/resources/js/objectModel/ObjectModelCollection.js
@@ -1,4 +1,4 @@
-import F from '../utilities/Formatter'
+import F from '@utilities/Formatter'
 import Attribute from './Attribute'
 import ObjectModelEntityFactory from './ObjectModelEntityFactory'
 import collect from 'collect.js'

--- a/src/resources/js/objectModel/ObjectModelEntity.js
+++ b/src/resources/js/objectModel/ObjectModelEntity.js
@@ -1,7 +1,7 @@
-import F from '../utilities/Formatter'
+import F from '@utilities/Formatter'
 import Attribute from './Attribute.js';
 import AttributeFactory from './AttributeFactory.js';
-import Preference from '../utilities/Preference'
+import Preference from '@utilities/Preference'
 
 export default class ObjectModelEntity {
     constructor() {

--- a/src/resources/js/objectModel/ObjectModelEntityFactory.js
+++ b/src/resources/js/objectModel/ObjectModelEntityFactory.js
@@ -1,7 +1,7 @@
-import UserEntity from './entities/UserEntity'
-import ModelEntity from './entities/ModelEntity'
-import TableEntity from './entities/TableEntity'
-import PivotTableEntity from './entities/PivotTableEntity'
+import UserEntity from '@entities/UserEntity'
+import ModelEntity from '@entities/ModelEntity'
+import TableEntity from '@entities/TableEntity'
+import PivotTableEntity from '@entities/PivotTableEntity'
 const EntityTypes = { UserEntity, ModelEntity, TableEntity, PivotTableEntity};
 
 

--- a/src/resources/js/objectModel/Segment.js
+++ b/src/resources/js/objectModel/Segment.js
@@ -1,4 +1,4 @@
-import F from '../utilities/Formatter'
+import F from '@utilities/Formatter'
 
 export default class Segment {
     constructor(chunk) {

--- a/src/resources/js/store/index.js
+++ b/src/resources/js/store/index.js
@@ -3,7 +3,7 @@ import Vuex from 'vuex'
 import Parser from '../objectModel/SketchParser'
 import ObjectModelCollection from '../objectModel/ObjectModelCollection'
 import ObjectModelEntityFactory from '../objectModel/ObjectModelEntityFactory'
-import Config from '../Config'
+import Config from '@/Config'
 const mergeJSON = require('deepmerge')
 
 Vue.use(Vuex)

--- a/src/resources/js/utilities/Preference.js
+++ b/src/resources/js/utilities/Preference.js
@@ -1,4 +1,4 @@
-import Config from '../Config'
+import Config from '@/Config'
 const mergeJSON = require('deepmerge')
 import store from '../store'
 

--- a/src/routes/routes.php
+++ b/src/routes/routes.php
@@ -1,14 +1,13 @@
-<?php 
+<?php
+
 
 Route::get('/pipe-dream', '\PipeDream\Laravel\Controllers\PipeDreamWebController@index');
-Route::get('/pipe-dream/test', function() {
+Route::get('/pipe-dream/test', function () {
     return \Artisan::call('dump-autoload');
 });
 
-
 Route::prefix('pipe-dream/api')->group(function () {
-    Route::post('/build',    '\PipeDream\Laravel\Controllers\PipeDreamAPIController@build');
+    Route::post('/build', '\PipeDream\Laravel\Controllers\PipeDreamAPIController@build');
     Route::get('/scripts', '\PipeDream\Laravel\Controllers\PipeDreamAPIController@scripts');
     Route::get('/templates', '\PipeDream\Laravel\Controllers\PipeDreamAPIController@templates');
-    
 });

--- a/src/templates/HasOneRelationship
+++ b/src/templates/HasOneRelationship
@@ -1,0 +1,7 @@
+/**
+ * Get the ___TARGET_CLASS___ for the ___THIS_CLASS___.
+ */
+public function ___METHOD_NAME___()
+{
+    return $this->hasOne('App\___TARGET_CLASS___');
+}


### PR DESCRIPTION
This PR add some alias for your package modules:

```json
 "_moduleAliases": {
        "@utilities": "src/resources/js/utilities",
        "@pipes": "src/resources/js/fileFactories/Laravel/pipes",
        "@preferences": "src/resources/js/fileFactories/Laravel/preferences",
        "@sketches": "src/resources/js/fileFactories/Laravel/sketches",
        "@entities": "src/resources/js/objectModel/entities",
        "@": "src/resources/js"
    }
```

Now, it's easy to import files:
This line:
```js
import Template from '../../../utilities/Template'
```
can now be imported as
```js
import Template from '@utilities/Template'
```