### PR TITLE
Added auto selection of $casts

### DIFF
--- a/src/resources/js/fileFactories/Laravel/pipes/ModelPipe.js
+++ b/src/resources/js/fileFactories/Laravel/pipes/ModelPipe.js
@@ -12,7 +12,7 @@ export default class ModelPipe extends BasePipe {
                     ___HIDDEN___: this.hiddenAttributes(model),
                     ___FILLABLE___: this.fillableAttributes(model),
                     ___CASTS_BLOCK___: this.casts(model) ? this.casts(model) : "//",
-                    ___RELATIONSHIP_METHODS_BLOCK___: this.relationshipMethods(model),                
+                    ___RELATIONSHIP_METHODS_BLOCK___: this.relationshipMethods(model),
                 })
             }
         })
@@ -31,25 +31,52 @@ export default class ModelPipe extends BasePipe {
             model.attributes.filter(attribute => attribute.fillable)
                 .map(attribute => attribute.name),
             "//" // default value
-        )        
+        )
     }
 
     casts(model) {
+
+        const dataTypeCasts = {
+            'int' : 'integer',
+            'integer' : 'integer',
+            'real' : 'real',
+            'float' : 'float',
+            'double' : 'double',
+
+            'string' : 'string',
+
+            'bit' : 'boolean',
+            'boolean' : 'boolean',
+
+            'date' : 'date',
+            'datetime' : 'datetime',
+            'timestamp' : 'timestamp',
+
+            'array' : 'array',
+            'json' : 'object',
+            'collection' : 'collection'
+        }
+
+        model.attributes.forEach(attribute => {
+            if(attribute.cast === null && dataTypeCasts[attribute.dataType])
+                attribute.cast = dataTypeCasts[attribute.dataType]
+        })
+
         return model.attributes.filter(attribute => attribute.cast)
             .map(attribute => "'" + attribute.name + "' => '" + attribute.cast + "'")
             .join(",\n")
-        
+
     }
 
     className(model) {
         return model.name
     }
-    
+
     relationshipMethods(model) {
         return [
             model.relationships.hasOne.map(target => {
                 return Template.for('HasOneRelationship').replace({
-                    ___TARGET_CLASS___: target.className(),                    
+                    ___TARGET_CLASS___: target.className(),
                     ___THIS_CLASS___: model.className(),
                     ___METHOD_NAME___: F.camelCase(
                         target.className()
@@ -60,7 +87,7 @@ export default class ModelPipe extends BasePipe {
 
             model.relationships.hasMany.map(target => {
                 return Template.for('HasManyRelationship').replace({
-                    ___TARGET_CLASS___: target.className(),                    
+                    ___TARGET_CLASS___: target.className(),
                     ___TARGET_CLASS_PLURAL___: F.pluralize(target.className()),
                     ___THIS_CLASS___: model.className(),
                     ___METHOD_NAME___: F.pluralize(
@@ -82,7 +109,7 @@ export default class ModelPipe extends BasePipe {
 
             model.relationships.belongsToMany.map(target => {
                 return Template.for('BelongsToManyRelationship').replace({
-                    ___TARGET_CLASS___: target.className(),                    
+                    ___TARGET_CLASS___: target.className(),
                     ___TARGET_CLASS_PLURAL___: F.pluralize(target.className()),
                     ___THIS_CLASS___: model.className(),
                     ___METHOD_NAME___: F.pluralize(


### PR DESCRIPTION
If the user doesn't manually writes to the "casts" attribute of a model, it will try to automatically select a cast from a predetermined list of available casts.

Any manual interaction with the "casts" attribute will overwrite the auto-selection