### PR TITLE
Fix newline parsing when generating file in windows

### DIFF
--- a/src/resources/js/objectModel/SketchParser.js
+++ b/src/resources/js/objectModel/SketchParser.js
@@ -15,6 +15,8 @@ export default class SketchParser {
 
     clean() {
         this.text = this.text
+            // force UNIX-style line ending (LF)
+            .replace(/\r\n/gm, "\n")
             // remove comments
             .replace(/\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm, "")        
             // trim preciding line space


### PR DESCRIPTION
This fix leftover CRLF ending when generating files in Windows machine.

Add regex in parser logic to strip `\r` and `\n` on beginning and end of line.