### PR TITLE
Optional softdeletes on models

### DIFF
--- a/mix-manifest.json
+++ b/mix-manifest.json
@@ -1,6 +1,6 @@
 {
     "/src/public/js/app.js": "/src/public/js/app.js",
     "/src/public/css/app.css": "/src/public/css/app.css",
-    "/Users/anders/Code/skeleton/public/vendor/pipe-dream/laravel/css/app.css": "/Users/anders/Code/skeleton/public/vendor/pipe-dream/laravel/css/app.css",
-    "/Users/anders/Code/skeleton/public/vendor/pipe-dream/laravel/js/app.js": "/Users/anders/Code/skeleton/public/vendor/pipe-dream/laravel/js/app.js"
+    "/C:/public/vendor/pipe-dream/laravel/css/app.css": "/C:/public/vendor/pipe-dream/laravel/css/app.css",
+    "/C:/public/vendor/pipe-dream/laravel/js/app.js": "/C:/public/vendor/pipe-dream/laravel/js/app.js"
 }

--- a/src/resources/js/fileFactories/Laravel/pipes/MigrationPipe.js
+++ b/src/resources/js/fileFactories/Laravel/pipes/MigrationPipe.js
@@ -12,6 +12,7 @@ export default class MigrationPipe extends BasePipe {
                     ___CLASS_NAME___: this.migrationFileClassName(entity),
                     ___TABLE___: this.tableName(entity),
                     ___COLUMNS_BLOCK___: this.columns(entity),
+                    ___SOFT_DELETES_BLOCK: entity.softdeletes ? "$table->softDeletes();" : ""
                 })
             }
         })
@@ -28,7 +29,7 @@ export default class MigrationPipe extends BasePipe {
     tableName(entity) {
         if(!(entity instanceof ModelEntity)) {
             return entity.name
-        }  
+        }
 
         return F.snakeCase(F.pluralize(entity.name))
     }
@@ -42,7 +43,7 @@ export default class MigrationPipe extends BasePipe {
     statementsFor(attribute) {
         return [
             `$table->${attribute.dataType}('${attribute.name}')${this.chainings(attribute)};`,
-            ... this.addForeignKeyConstraintFor(attribute) 
+            ... this.addForeignKeyConstraintFor(attribute)
         ].join(___SINGLE_LINE_BREAK___)
     }
 
@@ -58,9 +59,9 @@ export default class MigrationPipe extends BasePipe {
         if(attribute.nullable) chainings += "->nullable()";
         if(attribute.unique) chainings += "->unique()";
         return chainings
-        
+
     }
-    
+
     migrationTimeStamp(index) {
         let current_datetime = new Date()
         return current_datetime.getFullYear() + "_"

--- a/src/resources/js/fileFactories/Laravel/pipes/MigrationPipe.js
+++ b/src/resources/js/fileFactories/Laravel/pipes/MigrationPipe.js
@@ -12,7 +12,7 @@ export default class MigrationPipe extends BasePipe {
                     ___CLASS_NAME___: this.migrationFileClassName(entity),
                     ___TABLE___: this.tableName(entity),
                     ___COLUMNS_BLOCK___: this.columns(entity),
-                    ___SOFT_DELETES_BLOCK: entity.softdeletes ? "$table->softDeletes();" : ""
+                    ___SOFT_DELETES_BLOCK___: entity.softdeletes ? "$table->softDeletes();" : ""
                 })
             }
         })

--- a/src/resources/js/fileFactories/Laravel/pipes/ModelPipe.js
+++ b/src/resources/js/fileFactories/Laravel/pipes/ModelPipe.js
@@ -13,7 +13,7 @@ export default class ModelPipe extends BasePipe {
                     ___FILLABLE___: this.fillableAttributes(model),
                     ___CASTS_BLOCK___: this.casts(model) ? this.casts(model) : "//",
                     ___RELATIONSHIP_METHODS_BLOCK___: this.relationshipMethods(model),
-                    ___SOFT_DELETES_BLOCK : model.softdeletes ? "Soft deletes" : ""
+                    ___SOFT_DELETES_BLOCK___ : model.softdeletes ? "Soft deletes" : ""
                 })
             }
         })

--- a/src/resources/js/fileFactories/Laravel/pipes/ModelPipe.js
+++ b/src/resources/js/fileFactories/Laravel/pipes/ModelPipe.js
@@ -13,7 +13,7 @@ export default class ModelPipe extends BasePipe {
                     ___FILLABLE___: this.fillableAttributes(model),
                     ___CASTS_BLOCK___: this.casts(model) ? this.casts(model) : "//",
                     ___RELATIONSHIP_METHODS_BLOCK___: this.relationshipMethods(model),
-                    ___SOFT_DELETES_BLOCK___ : this.softDeletes(model) ? "use Illuminate\\Database\\Eloquent\\SoftDeletes;" : ""
+                    ___SOFT_DELETES_BLOCK___ : this.softDeletes(model) ? "use \\Illuminate\\Database\\Eloquent\\SoftDeletes;" : ""
                 })
             }
         })

--- a/src/resources/js/fileFactories/Laravel/pipes/ModelPipe.js
+++ b/src/resources/js/fileFactories/Laravel/pipes/ModelPipe.js
@@ -13,6 +13,7 @@ export default class ModelPipe extends BasePipe {
                     ___FILLABLE___: this.fillableAttributes(model),
                     ___CASTS_BLOCK___: this.casts(model) ? this.casts(model) : "//",
                     ___RELATIONSHIP_METHODS_BLOCK___: this.relationshipMethods(model),
+                    ___SOFT_DELETES_BLOCK : model.softdeletes ? "Soft deletes" : ""
                 })
             }
         })

--- a/src/resources/js/fileFactories/Laravel/pipes/ModelPipe.js
+++ b/src/resources/js/fileFactories/Laravel/pipes/ModelPipe.js
@@ -13,10 +13,14 @@ export default class ModelPipe extends BasePipe {
                     ___FILLABLE___: this.fillableAttributes(model),
                     ___CASTS_BLOCK___: this.casts(model) ? this.casts(model) : "//",
                     ___RELATIONSHIP_METHODS_BLOCK___: this.relationshipMethods(model),
-                    ___SOFT_DELETES_BLOCK___ : model.softdeletes ? "Soft deletes" : ""
+                    ___SOFT_DELETES_BLOCK___ : this.softDeletes(model) ? "use Illuminate\\Database\\Eloquent\\SoftDeletes;" : ""
                 })
             }
         })
+    }
+
+    softDeletes(model){
+        return model.softdeletes
     }
 
     hiddenAttributes(model) {

--- a/src/resources/js/objectModel/ObjectModelEntity.js
+++ b/src/resources/js/objectModel/ObjectModelEntity.js
@@ -11,6 +11,7 @@ export default class ObjectModelEntity {
     static fromSegment(segment, allSegments) {
         let entity = new this()
         entity.name = segment.name
+        entity.softdeletes = segment.softdeletes
         entity.allSegments = allSegments
         // Sort and only keep unique attributes
         let attributeRows = [
@@ -20,13 +21,14 @@ export default class ObjectModelEntity {
                 ... entity.optionalColumns(['created_at', 'updated_at']),
             ])
         ]
-        entity.attributes = attributeRows.map(name => AttributeFactory.make(name, entity, allSegments))        
+        entity.attributes = attributeRows.map(name => AttributeFactory.make(name, entity, allSegments))
         return entity
     }
 
     static deserialize(data) {
         let entity = new this()
         entity.name = data.name
+        entity.softdeletes = data.softdeletes
         entity.attributes = Object.keys(data.attributes).map(key => {
             return new Attribute({
                 ...data.attributes[key],
@@ -34,7 +36,7 @@ export default class ObjectModelEntity {
             })
         })
         entity.relationships = data.relationships
-        return entity        
+        return entity
     }
 
     attributeNames() {
@@ -69,13 +71,13 @@ export default class ObjectModelEntity {
     isModelEntity() {
         return this.constructor.name == "ModelEntity"
     }
-    
+
     isTableEntity() {
         return this.constructor.name == "TableEntity"
     }
-    
+
     asForeignKey() {
-        return F.snakeCase(this.name) + "_id";       
+        return F.snakeCase(this.name) + "_id";
     }
 
     serialize() {
@@ -94,7 +96,7 @@ export default class ObjectModelEntity {
                 belongsToMany: this.relationships.belongsToMany.map(target => target.name)
             }
         }
-        
-        return  serialize_results; 
+
+        return  serialize_results;
     }
 }

--- a/src/resources/js/objectModel/ObjectModelEntity.js
+++ b/src/resources/js/objectModel/ObjectModelEntity.js
@@ -6,6 +6,7 @@ import Preference from '@utilities/Preference'
 export default class ObjectModelEntity {
     constructor() {
         this.relationships = {}
+        this.softdeletes = false
     }
 
     static fromSegment(segment, allSegments) {
@@ -84,6 +85,7 @@ export default class ObjectModelEntity {
         const serialize_results = {
             name: this.name,
             type: this.constructor.name,
+            softdeletes: this.softdeletes,
             //attributes: this.attributes.map(attribute => attribute.serialize()),
             attributes: this.attributes.reduce((carry, attribute) => {
                 carry[attribute.name] = attribute.serialize()

--- a/src/resources/js/objectModel/Segment.js
+++ b/src/resources/js/objectModel/Segment.js
@@ -5,6 +5,9 @@ export default class Segment {
         let parts = chunk.split('\n')
         this.name = parts[0]
         this.attributes = parts.slice(1)
+        this.softdeletes = this.attributes[0] === "softdeletes"
+        if(this.softdeletes)
+            this.attributes = parts.slice(2)
     }
 
     static fromText(chunk) {
@@ -18,5 +21,5 @@ export default class Segment {
 
     hasUserModel() {
         return this.name == "User"
-    }    
+    }
 }

--- a/src/templates/Migration
+++ b/src/templates/Migration
@@ -15,6 +15,7 @@ class ___CLASS_NAME___ extends Migration
     {
         Schema::create('___TABLE___', function (Blueprint $table) {
             ___COLUMNS_BLOCK___
+            ___SOFT_DELETES_BLOCK___
         });
     }
 

--- a/src/templates/Model
+++ b/src/templates/Model
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class ___CLASS_NAME___ extends Model
 {
+    ___SOFT_DELETES_BLOCK___
     /**
      * The attributes that are mass assignable.
      *
@@ -31,7 +32,7 @@ class ___CLASS_NAME___ extends Model
      */
     protected $casts = [
         ___CASTS_BLOCK___
-    ];    
+    ];
 
     ___RELATIONSHIP_METHODS_BLOCK___
 }


### PR DESCRIPTION
SoftDeletes are awesome, and should be used everywhere. Makes it easier to restore "accidentally" deleted items etc.

This PR implements SoftDeletes on all models, disabled by default
SoftDeletes can be enabled either by manually setting the `softdeletes` property in the Schema, or by having a models _first_ attribute be `softdeletes`

The migration will automatically append the `softdeletes` column, and the model will also have the `use softdeletes`.

Example:
```
// This will not have softdeletes. Deletion of models will be permanent
Car
brand
color
user_id
```

```
// Identical to the above model, but Car::first()->delete() can be restored by changing the deleted_at timestamp to null
Car
softdeletes
brand
color
user_id
```
