### PR TITLE
Make all timestamp datatype nullable by default

### DIFF
--- a/src/resources/js/fileFactories/Laravel/pipes/MigrationPipe.js
+++ b/src/resources/js/fileFactories/Laravel/pipes/MigrationPipe.js
@@ -56,7 +56,7 @@ export default class MigrationPipe extends BasePipe {
     chainings(attribute) {
         let chainings = ""
         if(attribute.index) chainings += "->index()";
-        if(attribute.nullable) chainings += "->nullable()";
+        if(attribute.nullable || attribute.dataType === "timestamp") chainings += "->nullable()";
         if(attribute.unique) chainings += "->unique()";
         return chainings
 


### PR DESCRIPTION
saves tons of headaches when writing big project with tons of timestamps.
Every column that have a `datatype` of `timestamp` will automatically have `->nullable()` in their migration.