### PR TITLE
Object model fixes

### DIFF
--- a/src/resources/js/objectModel/ObjectModelCollection.js
+++ b/src/resources/js/objectModel/ObjectModelCollection.js
@@ -32,16 +32,8 @@ export default class ObjectModelCollection {
         if(!this.isManyToMany(candidate))
             return []
 
-        let models = ObjectModelCollection.getModelRegexString(this.modelsIncludingUser())
-    }
-
-    manyToManyAssociatedModels(manyToManyEntity) {
-        var models = this.modelsIncludingUser().map((item) => {
-            return F.snakeCase(item.name).toLowerCase();
-        }).toArray().join("|");
-        var manyToManyRegExp = new RegExp("^(" + models + ")_(" + models + ")$");
-        var matches = manyToManyRegExp.exec(manyToManyEntity.name);
-        return [matches[1], matches[2]];
+        let models = this.regexes.manyToMany().exec(candidate.name);
+        return [models[1], models[2]]
     }
 
     hasUserModel() {
@@ -57,19 +49,19 @@ export default class ObjectModelCollection {
     }
 
     userModels() {
-        return this.entities.filter(entitiy => entitiy.isUserEntity())
+        return this.entities.filter(entity => entity.isUserEntity())
     }
 
     models() {
-        return this.entities.filter(entitiy => entitiy.isModelEntity())
+        return this.entities.filter(entity => entity.isModelEntity())
     }
 
     tablesOnly() {
-        return this.entities.filter(entity => entity.name == entity.name.toLowerCase())
+        return this.entities.filter(entity => entity.name === entity.name.toLowerCase())
     }
 
     manyToManys() {
-        return this.tablesOnly().filter(entitiy => this.isManyToMany(entitiy))
+        return this.tablesOnly().filter(entity => this.isManyToMany(entity))
     }
 
     modelsIncludingUser() {
@@ -135,25 +127,6 @@ export default class ObjectModelCollection {
         }
 
         return sortedEntities.concat(manyToMany)
-    }
-
-    attachPivotAttributes() {
-        this.manyToManys().each(entity => {
-            this.manyToManyAssociatedModels(entity).forEach(modelName => {
-                entity.attributes.push(
-                    new Attribute(
-                        {
-                            name: F.snakeCase(modelName) + "_id",
-                            parent: entity,
-                            dataType: "unsignedBigInteger",
-                            fillable: false,
-                            hidden: false,
-                            nullable: false,
-                        }
-                    )
-                )
-            })
-        })
     }
 
     serializeSchema() {


### PR DESCRIPTION
Fixed some issues in the ObjectModelCollection file:

- The constructor can now be instantiated with an array of entities.
- `fromEntities` and `fromSchema` has been simplified.
- Moved the model RegExp generation into the constructor.
- Removed `attachPivotAttributes` method since it wasn't used.
- `this.entities` has been added to the constructor to allow for better code-completion.
- `isManyToMany` method no longer have two different return types (used to be `boolean` or `array`), it will now always return a boolean.
- Fixed a few typos