### PR TITLE
Use `new ResourceCollection()` instead of `Resource::collection()` in Resource Pipe.

### DIFF
--- a/src/resources/js/fileFactories/Laravel/pipes/APIResourcePipe.js
+++ b/src/resources/js/fileFactories/Laravel/pipes/APIResourcePipe.js
@@ -29,7 +29,7 @@ export default class APIResourcePipe extends ModelPipe {
         }).map(attribute => {
             return F.singleQuotePad(attribute.name) + " => $this->" + attribute.name
         }).concat(model.relationships.hasMany.concat(model.relationships.belongsToMany).map(target => {
-            return F.singleQuotePad(F.snakeCase(F.pluralize(target.name))) + " => " + F.pascalCase(target.name) + "Resource::collection($this->whenLoaded(" + F.singleQuotePad(F.snakeCase(F.pluralize(target.name))) + "))"
+            return F.singleQuotePad(F.snakeCase(F.pluralize(target.name))) + " => new " + F.pascalCase(target.name) + "Collection($this->whenLoaded(" + F.singleQuotePad(F.snakeCase(F.pluralize(target.name))) + "))"
         })).concat(model.relationships.belongsTo.map(target => {
             return F.singleQuotePad(F.snakeCase(target.name)) + " => new " + F.pascalCase(target.name) + "Resource($this->whenLoaded(" + F.singleQuotePad(F.snakeCase(target.name)) + "))"
         })).join(",\n")


### PR DESCRIPTION
Hi guys! Thanks for building such an awesome tool!

I've updated the Resource Pipe to use `new ResourceCollection()` instead of `Resource::collection()` since `Resource::collection()` returns `\Illuminate\Http\Resources\Json\AnonymousResourceCollection` instead of `ResourceCollection`. This way any parsers/analyzers/third-party packages could match the types correctly. For example I'm building an automated Laravel API documentation generator, and it would useful to know that it's a `ResourceCollection` instead of `AnonymousResourceCollection`.

Sorry I didn't test and didn't build it for now, did the commit directly from GitHub. I'd like to hear your opinion first.
