### PR TITLE
Fix/pad migration timestamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ migrations_metadata.csv
 package-lock.json
 .vscode
 yarn.lock
+mix-manifest.json

--- a/mix-manifest.json
+++ b/mix-manifest.json
@@ -1,6 +1,6 @@
 {
     "/src/public/js/app.js": "/src/public/js/app.js",
     "/src/public/css/app.css": "/src/public/css/app.css",
-    "/C:/public/vendor/pipe-dream/laravel/css/app.css": "/C:/public/vendor/pipe-dream/laravel/css/app.css",
-    "/C:/public/vendor/pipe-dream/laravel/js/app.js": "/C:/public/vendor/pipe-dream/laravel/js/app.js"
+    "/Users/anders/Code/skeleton/public/vendor/pipe-dream/laravel/css/app.css": "/Users/anders/Code/skeleton/public/vendor/pipe-dream/laravel/css/app.css",
+    "/Users/anders/Code/skeleton/public/vendor/pipe-dream/laravel/js/app.js": "/Users/anders/Code/skeleton/public/vendor/pipe-dream/laravel/js/app.js"
 }

--- a/mix-manifest.json
+++ b/mix-manifest.json
@@ -1,6 +1,0 @@
-{
-    "/src/public/js/app.js": "/src/public/js/app.js",
-    "/src/public/css/app.css": "/src/public/css/app.css",
-    "/Users/anders/Code/skeleton/public/vendor/pipe-dream/laravel/css/app.css": "/Users/anders/Code/skeleton/public/vendor/pipe-dream/laravel/css/app.css",
-    "/Users/anders/Code/skeleton/public/vendor/pipe-dream/laravel/js/app.js": "/Users/anders/Code/skeleton/public/vendor/pipe-dream/laravel/js/app.js"
-}

--- a/src/resources/js/fileFactories/Laravel/pipes/MigrationPipe.js
+++ b/src/resources/js/fileFactories/Laravel/pipes/MigrationPipe.js
@@ -59,7 +59,6 @@ export default class MigrationPipe extends BasePipe {
         if(attribute.nullable || attribute.dataType === "timestamp") chainings += "->nullable()";
         if(attribute.unique) chainings += "->unique()";
         return chainings
-
     }
 
     migrationTimeStamp(index) {

--- a/src/resources/js/fileFactories/Laravel/pipes/MigrationPipe.js
+++ b/src/resources/js/fileFactories/Laravel/pipes/MigrationPipe.js
@@ -61,7 +61,7 @@ export default class MigrationPipe extends BasePipe {
         return chainings
     }
 
-    migrationTimeStamp(index) {
+    _migrationTimeStamp(index) {
         let current_datetime = new Date()
         return current_datetime.getFullYear() + "_"
             + (current_datetime.getMonth() + 1 < 10 ? "0" + (current_datetime.getMonth() + 1) : current_datetime.getMonth() + 1)
@@ -69,6 +69,22 @@ export default class MigrationPipe extends BasePipe {
             + "_" + current_datetime.getHours()
             + (current_datetime.getMinutes() < 10 ? "0" + current_datetime.getMinutes() : current_datetime.getMinutes())
             + (index < 10 ? "0" + index : index)
+    }
+
+    migrationTimeStamp(index) {
+        // prepare timestamp parts
+        let current_datetime = new Date(),
+            year = current_datetime.getFullYear(),
+            month = String(current_datetime.getMonth() + 1).padStart(2,'0'),
+            day = String(current_datetime.getDate()).padStart(2,'0'),
+            hour = String(current_datetime.getHours()).padStart(2,'0'),
+            minute = String(current_datetime.getMinutes()).padStart(2,'0')
+
+        // Assume at most 99 migrations
+        index = String(index).padStart(2,'0')
+
+        // Example: 2014_10_12_000000
+        return `${year}_${month}_${day}_${hour}${minute}${index}`
     }
 }
 

--- a/src/resources/js/fileFactories/Laravel/pipes/MigrationPipe.js
+++ b/src/resources/js/fileFactories/Laravel/pipes/MigrationPipe.js
@@ -70,7 +70,6 @@ export default class MigrationPipe extends BasePipe {
             + "_" + current_datetime.getHours()
             + (current_datetime.getMinutes() < 10 ? "0" + current_datetime.getMinutes() : current_datetime.getMinutes())
             + (index < 10 ? "0" + index : index)
-
     }
 }
 

--- a/src/resources/js/fileFactories/Laravel/pipes/MigrationPipe.js
+++ b/src/resources/js/fileFactories/Laravel/pipes/MigrationPipe.js
@@ -61,16 +61,6 @@ export default class MigrationPipe extends BasePipe {
         return chainings
     }
 
-    _migrationTimeStamp(index) {
-        let current_datetime = new Date()
-        return current_datetime.getFullYear() + "_"
-            + (current_datetime.getMonth() + 1 < 10 ? "0" + (current_datetime.getMonth() + 1) : current_datetime.getMonth() + 1)
-            + "_" + (current_datetime.getDate() < 10 ? "0" + current_datetime.getDate() : current_datetime.getDate())
-            + "_" + current_datetime.getHours()
-            + (current_datetime.getMinutes() < 10 ? "0" + current_datetime.getMinutes() : current_datetime.getMinutes())
-            + (index < 10 ? "0" + index : index)
-    }
-
     migrationTimeStamp(index) {
         // prepare timestamp parts
         let current_datetime = new Date(),

--- a/src/resources/js/fileFactories/Laravel/pipes/MigrationPipe.js
+++ b/src/resources/js/fileFactories/Laravel/pipes/MigrationPipe.js
@@ -66,7 +66,7 @@ export default class MigrationPipe extends BasePipe {
         let current_datetime = new Date()
         return current_datetime.getFullYear() + "_"
             + (current_datetime.getMonth() + 1 < 10 ? "0" + (current_datetime.getMonth() + 1) : current_datetime.getMonth() + 1)
-            + "_" + current_datetime.getDate()
+            + "_" + (current_datetime.getDate() < 10 ? "0" + current_datetime.getDate() : current_datetime.getDate())
             + "_" + current_datetime.getHours()
             + (current_datetime.getMinutes() < 10 ? "0" + current_datetime.getMinutes() : current_datetime.getMinutes())
             + (index < 10 ? "0" + index : index)


### PR DESCRIPTION
### Added zero padding to the date part of migration names
Previous:
`2019_11_7_101900_create_car_garage_table.php`
Now:
`2019_11_07_101900_create_car_garage_table.php`

Im testing out the PR/branch workflow, would appreciate a reviewer.